### PR TITLE
fix: revertTreeString regex

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -68,7 +68,7 @@ export function createWebview(context: vscode.ExtensionContext, text = '') {
 export function revertTreeString(treeString: string, replaceWith = '#') {
   const { child, last, parent, dash, blank } = getCharCodesFromConfig();
   //  [└├]──|│ {3}|^( {4})+?|(?= {4})( {4})+?|( {4})(?=[└├│])
-  const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(?=${blank}{4})(${blank}{4})+?|(${blank}{4})(?=[${last}${child}${parent}])`, 'gm');
+  const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(${blank}{4})(?=.*[${last}${child}${parent}])`, 'gm');
   return treeString.replace(reg, replaceWith);
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,7 +67,7 @@ export function createWebview(context: vscode.ExtensionContext, text = '') {
 /** create a revert regexp according to current config, and revert tree-string back */
 export function revertTreeString(treeString: string, replaceWith = '#') {
   const { child, last, parent, dash, blank } = getCharCodesFromConfig();
-  //  [└├]──|│ {3}|^( {4})+?|(?= {4})( {4})+?|( {4})(?=[└├│])
+  //  [└├]──|│ {3}|^( {4})+?|( {4})(?=.*[└├│])
   const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(${blank}{4})(?=.*[${last}${child}${parent}])`, 'gm');
   return treeString.replace(reg, replaceWith);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -67,8 +67,8 @@ export function createWebview(context: vscode.ExtensionContext, text = '') {
 /** create a revert regexp according to current config, and revert tree-string back */
 export function revertTreeString(treeString: string, replaceWith = '#') {
   const { child, last, parent, dash, blank } = getCharCodesFromConfig();
-  //  [└├]──|│ {3}| *(?=[└├│])
-  const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|${blank}*(?=[${last}${child}${parent}])`, 'gm');
+  //  [└├]──|│ {3}|^( {4})+?|(?= {4})( {4})+?|( {4})(?=[└├│])
+  const reg = new RegExp(`[${last}${child}]${dash}${dash}|${parent}${blank}{3}|^(${blank}{4})+?|(?=${blank}{4})(${blank}{4})+?|(${blank}{4})(?=[${last}${child}${parent}])`, 'gm');
   return treeString.replace(reg, replaceWith);
 }
 


### PR DESCRIPTION
Support to revert more depth tree-string

```.
├── .
└── a
    ├── b
    │   └── b
    │       └── b
    │           └── b
    │               └── b
    │                   └── b
    │                       └── b
    │                           └── b
    │                               └── b
    └── b
```

revert result
```.
# .
# a
## b
### b
#### b
##### b
###### b
####### b
######## b
######### b
########## b
## b
```
---
```
.
├── .
├── .
└── a
    ├── b
    │   └── b
    │       └── b
    │           └── b
    │               └── b
    │                   └── b
    │                       └── b
    │                           └── b
    │                               └── b                 b
    └── b
```
revert result
```
.
# .
# .
# a
## b
### b
#### b
##### b
###### b
####### b
######## b
######### b
########## b                 b
## b
```